### PR TITLE
HOTFIX: error PropTypes corrected to string

### DIFF
--- a/src/components/ui/atoms/FormInput/FormInput.component.jsx
+++ b/src/components/ui/atoms/FormInput/FormInput.component.jsx
@@ -34,7 +34,7 @@ export default function FormInput({
 
 FormInput.propTypes = {
   // What results in an error?
-  error: PropTypes.func,
+  error: PropTypes.string,
   // What label text should be rendered?
   label: PropTypes.string,
   // What is the unique id, name and label identifier?

--- a/src/components/ui/molecules/Form/Form.component.jsx
+++ b/src/components/ui/molecules/Form/Form.component.jsx
@@ -74,7 +74,7 @@ Form.defaultProps = {
 
 FormInput.propTypes = {
   // What results in an error?
-  error: PropTypes.func,
+  error: PropTypes.string,
   // What label text should be rendered?
   label: PropTypes.string,
   // What is the unique id, name and label identifier?


### PR DESCRIPTION
Corrected the `PropTypes` of `func` to `string` for both the `Form` and `FormInput` components