### PR TITLE
FEATURE: Unique UserProfile driven by userId

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import { Switch, Route } from "react-router-dom";
 import { AuthRoute } from "./utils";
 import { darkTheme, lightTheme } from "./themes";
 import { Header, SideMenu } from "./components/ui";
-import { Home, Posts, SignIn, SignUp } from "./components/pages";
+import { Home, Posts, SignIn, SignUp, UserProfile } from "./components/pages";
 
 export default function App() {
   const isGlobalThemeDark = useSelector((state) => {
@@ -29,6 +29,7 @@ export default function App() {
           <Switch>
             <Route exact path="/" component={Home} />
             <Route exact path="/posts" component={Posts} />
+            <Route path="/user&id=:userId" component={UserProfile} />
             <AuthRoute exact path="/sign-in" component={SignIn} />
             <AuthRoute exact path="/sign-up" component={SignUp} />
           </Switch>

--- a/src/components/pages/Posts/Posts.component.jsx
+++ b/src/components/pages/Posts/Posts.component.jsx
@@ -1,14 +1,24 @@
 import React from "react";
 import { useQuery } from "@apollo/client";
 import gql from "graphql-tag";
+import { Link } from "react-router-dom";
 
 import { Wrapper } from "./Posts.styles";
 
 export default function Posts() {
   const { loading, data, error } = useQuery(GET_POSTS_QUERY);
+  const {
+    loading: getUsersLoading,
+    data: getUsersData,
+    error: getUsersError,
+  } = useQuery(GET_USERS_QUERY);
 
   if (error) {
     return <span>Error!: {error}</span>;
+  }
+
+  if (getUsersError) {
+    return <span>Error!: {getUsersError}</span>;
   }
 
   return (
@@ -33,6 +43,21 @@ export default function Posts() {
                 <p>{post.body}</p>
                 <strong>{post.username}</strong>
                 <i>{post.createdAt}</i>
+              </div>
+            ))
+          )}
+
+          {getUsersLoading ? (
+            <span>Loading...</span>
+          ) : (
+            getUsersData &&
+            getUsersData.getUsers.map((user) => (
+              <div key={user.id} style={{ padding: "0.8rem 0" }}>
+                <p>{user.email}</p>
+                <Link to={`/user&id=${user.id}`}>
+                  <span>{user.username}</span>
+                </Link>
+                <i>{user.createdAt}</i>
               </div>
             ))
           )}
@@ -62,6 +87,17 @@ const GET_POSTS_QUERY = gql`
         createdAt
         body
       }
+    }
+  }
+`;
+
+const GET_USERS_QUERY = gql`
+  query {
+    getUsers {
+      createdAt
+      email
+      id
+      username
     }
   }
 `;

--- a/src/components/pages/Posts/Posts.component.jsx
+++ b/src/components/pages/Posts/Posts.component.jsx
@@ -1,22 +1,24 @@
 import React from "react";
-import { useQuery } from "@apollo/client";
-import gql from "graphql-tag";
 import { Link } from "react-router-dom";
 
+import { useGetPosts, useGetUsers } from "../../../hooks";
 import { Wrapper } from "./Posts.styles";
 
 export default function Posts() {
-  const { loading, data, error } = useQuery(GET_POSTS_QUERY);
+  const {
+    loading: getPostsLoading,
+    data: getPostsData,
+    error: getPostsError,
+  } = useGetPosts();
   const {
     loading: getUsersLoading,
     data: getUsersData,
     error: getUsersError,
-  } = useQuery(GET_USERS_QUERY);
+  } = useGetUsers();
 
-  if (error) {
-    return <span>Error!: {error}</span>;
+  if (getPostsError) {
+    return <span>Error!: {getPostsError}</span>;
   }
-
   if (getUsersError) {
     return <span>Error!: {getUsersError}</span>;
   }
@@ -34,11 +36,11 @@ export default function Posts() {
             maxWidth: "70%",
           }}
         >
-          {loading ? (
+          {getPostsLoading ? (
             <span>Loading...</span>
           ) : (
-            data &&
-            data.getPosts.map((post) => (
+            getPostsData &&
+            getPostsData.getPosts.map((post) => (
               <div key={post.id} style={{ padding: "0.8rem 0" }}>
                 <p>{post.body}</p>
                 <strong>{post.username}</strong>
@@ -66,38 +68,3 @@ export default function Posts() {
     </>
   );
 }
-
-const GET_POSTS_QUERY = gql`
-  query {
-    getPosts {
-      id
-      body
-      createdAt
-      username
-      likeCount
-      likes {
-        username
-        id
-        createdAt
-      }
-      commentCount
-      comments {
-        username
-        id
-        createdAt
-        body
-      }
-    }
-  }
-`;
-
-const GET_USERS_QUERY = gql`
-  query {
-    getUsers {
-      createdAt
-      email
-      id
-      username
-    }
-  }
-`;

--- a/src/components/pages/UserProfile/UserProfile.component.jsx
+++ b/src/components/pages/UserProfile/UserProfile.component.jsx
@@ -1,13 +1,64 @@
 import React from "react";
+import { useQuery } from "@apollo/client";
+import gql from "graphql-tag";
 
+import { ContentWrapper } from "../../templates";
 import { Wrapper } from "./UserProfile.styles";
 
-export default function UserProfile() {
+export default function UserProfile({ match }) {
+  const {
+    params: { userId },
+  } = match;
+
+  const { loading, data: { getUser: user } = {}, error } = useQuery(
+    GET_USER_QUERY,
+    {
+      variables: {
+        userId,
+      },
+    }
+  );
+
+  if (error) {
+    return <span>Error!: {error}</span>;
+  }
+
   return (
     <>
       <Wrapper>
-        <h1>User Profile</h1>
+        <ContentWrapper>
+          <div>
+            {loading ? (
+              <div>
+                <h1>User:</h1>
+                <span>Loading...</span>
+              </div>
+            ) : (
+              user && (
+                <div>
+                  <h1>User: {user.username}</h1>
+
+                  <h2>Username: {user.username}</h2>
+                  <h2>Email: {user.email}</h2>
+                  <h2>Created At: {user.createdAt}</h2>
+                  <h2>Id: {user.id}</h2>
+                </div>
+              )
+            )}
+          </div>
+        </ContentWrapper>
       </Wrapper>
     </>
   );
 }
+
+const GET_USER_QUERY = gql`
+  query($userId: ID!) {
+    getUser(userId: $userId) {
+      createdAt
+      email
+      id
+      username
+    }
+  }
+`;

--- a/src/components/pages/UserProfile/UserProfile.component.jsx
+++ b/src/components/pages/UserProfile/UserProfile.component.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+import { Wrapper } from "./UserProfile.styles";
+
+export default function UserProfile() {
+  return (
+    <>
+      <Wrapper>
+        <h1>User Profile</h1>
+      </Wrapper>
+    </>
+  );
+}

--- a/src/components/pages/UserProfile/UserProfile.component.jsx
+++ b/src/components/pages/UserProfile/UserProfile.component.jsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { useQuery } from "@apollo/client";
-import gql from "graphql-tag";
 
 import { ContentWrapper } from "../../templates";
+import { useGetUser } from "../../../hooks";
 import { Wrapper } from "./UserProfile.styles";
 
 export default function UserProfile({ match }) {
@@ -10,17 +9,19 @@ export default function UserProfile({ match }) {
     params: { userId },
   } = match;
 
-  const { loading, data: { getUser: user } = {}, error } = useQuery(
-    GET_USER_QUERY,
-    {
-      variables: {
-        userId,
-      },
-    }
-  );
+  const { loading, data: { getUser: user } = {}, error } = useGetUser(userId);
 
   if (error) {
-    return <span>Error!: {error}</span>;
+    return (
+      <>
+        <Wrapper>
+          <ContentWrapper>
+            <h1>User Profile</h1>
+            <h2>Error!: {error}</h2>
+          </ContentWrapper>
+        </Wrapper>
+      </>
+    );
   }
 
   return (
@@ -51,14 +52,3 @@ export default function UserProfile({ match }) {
     </>
   );
 }
-
-const GET_USER_QUERY = gql`
-  query($userId: ID!) {
-    getUser(userId: $userId) {
-      createdAt
-      email
-      id
-      username
-    }
-  }
-`;

--- a/src/components/pages/UserProfile/UserProfile.styles.js
+++ b/src/components/pages/UserProfile/UserProfile.styles.js
@@ -1,0 +1,3 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div``;

--- a/src/components/pages/index.js
+++ b/src/components/pages/index.js
@@ -2,3 +2,4 @@ export { default as Home } from "./Home/Home.component";
 export { default as Posts } from "./Posts/Posts.component";
 export { default as SignIn } from "./SignIn/SignIn.component";
 export { default as SignUp } from "./SignUp/SignUp.component";
+export { default as UserProfile } from "./UserProfile/UserProfile.component";

--- a/src/components/ui/molecules/SideMenuBody/SideMenuBody.component.jsx
+++ b/src/components/ui/molecules/SideMenuBody/SideMenuBody.component.jsx
@@ -22,7 +22,7 @@ export default function SideMenuBody() {
           Hi{" "}
           {user ? (
             <StyledLink
-              to={`user/${user.id}`}
+              to={`/user&id=${user.id}`}
               onClick={() => dispatch(setIsNavigationOpen())}
             >
               {user.username}

--- a/src/components/ui/molecules/SideMenuHeader/SideMenuHeader.component.jsx
+++ b/src/components/ui/molecules/SideMenuHeader/SideMenuHeader.component.jsx
@@ -34,7 +34,7 @@ export default function SideMenuHeader() {
           ) : (
             <>
               <Navigation.Item
-                to={`/user/${user.id}`}
+                to={`/user&id=${user.id}`}
                 onClick={() => dispatch(setIsNavigationOpen())}
               >
                 View Profile

--- a/src/components/ui/molecules/UserIndicator/UserIndicator.component.jsx
+++ b/src/components/ui/molecules/UserIndicator/UserIndicator.component.jsx
@@ -38,7 +38,7 @@ export default function UserIndicator({ left, user }) {
         <Dropdown left={left} user={user}>
           <Dropdown.Item
             onClick={() => dispatch(setIsDropdownOpen())}
-            to={`/user/${user.id}`}
+            to={`/user&id=${user.id}`}
             navlink
             leftIcon={<ViewProfileIcon />}
           >

--- a/src/hooks/gql/index.js
+++ b/src/hooks/gql/index.js
@@ -1,0 +1,3 @@
+import { useGetPosts, useGetUser, useGetUsers } from "./query";
+
+export { useGetPosts, useGetUser, useGetUsers };

--- a/src/hooks/gql/query/index.js
+++ b/src/hooks/gql/query/index.js
@@ -1,0 +1,5 @@
+import { useGetPosts } from "./useGetPosts";
+import { useGetUser } from "./useGetUser";
+import { useGetUsers } from "./useGetUsers";
+
+export { useGetPosts, useGetUser, useGetUsers };

--- a/src/hooks/gql/query/useGetPosts.js
+++ b/src/hooks/gql/query/useGetPosts.js
@@ -1,0 +1,32 @@
+import { useQuery } from "@apollo/client";
+import gql from "graphql-tag";
+
+const GET_POSTS_QUERY = gql`
+  query {
+    getPosts {
+      id
+      body
+      createdAt
+      username
+      likeCount
+      likes {
+        username
+        id
+        createdAt
+      }
+      commentCount
+      comments {
+        username
+        id
+        createdAt
+        body
+      }
+    }
+  }
+`;
+
+export const useGetPosts = () => {
+  const { loading, data, error } = useQuery(GET_POSTS_QUERY);
+
+  return { loading, data, error };
+};

--- a/src/hooks/gql/query/useGetUser.js
+++ b/src/hooks/gql/query/useGetUser.js
@@ -1,0 +1,23 @@
+import { useQuery } from "@apollo/client";
+import gql from "graphql-tag";
+
+const GET_USER_QUERY = gql`
+  query($userId: ID!) {
+    getUser(userId: $userId) {
+      id
+      username
+      email
+      createdAt
+    }
+  }
+`;
+
+export const useGetUser = (userId) => {
+  const { loading, data, error } = useQuery(GET_USER_QUERY, {
+    variables: {
+      userId,
+    },
+  });
+
+  return { loading, data, error };
+};

--- a/src/hooks/gql/query/useGetUsers.js
+++ b/src/hooks/gql/query/useGetUsers.js
@@ -1,0 +1,19 @@
+import { useQuery } from "@apollo/client";
+import gql from "graphql-tag";
+
+const GET_USERS_QUERY = gql`
+  query {
+    getUsers {
+      createdAt
+      email
+      id
+      username
+    }
+  }
+`;
+
+export const useGetUsers = () => {
+  const { loading, data, error } = useQuery(GET_USERS_QUERY);
+
+  return { loading, data, error };
+};

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,4 +1,5 @@
 import { useForm } from "./useForm";
+import { useGetPosts, useGetUser, useGetUsers } from "./gql";
 import { useWindowSize } from "./useWindowSize";
 
-export { useForm, useWindowSize };
+export { useForm, useGetPosts, useGetUser, useGetUsers, useWindowSize };


### PR DESCRIPTION
Unique `UserProfile` pages are now available by a `userId`, at `/user&id=:userId`. Additionally, GraphQL hooks are being migrated into the `hooks` folder to neaten code readability.

`useGetUser`, `useGetUsers` and `useGetPosts` added